### PR TITLE
update source upload to use license var

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -91,7 +91,7 @@ async function run(): Promise<void> {
       addonId,
       version.version,
       sourceZip,
-      "MIT"
+      license,
     );
     core.info(`Source "${sourcePath}" has been uploaded to "${src.source}"`);
   }


### PR DESCRIPTION
Currently, if you provide a source code file it is uploaded using the `"MIT"` license slug, regardless of what license was provided in the configuration

This change updates the source code uploader to use the same license variable used by `client.createVersion`

## Changelog
### Bug Fixes
* upload source code under addon license