### PR TITLE
feat: bump node version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -40,5 +40,5 @@ outputs:
     description: 'URL of the edit page of the uploaded version'
 
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "@types/form-data": "^2.5.0",
     "@types/jsonwebtoken": "^9.0.2",
     "@types/node": "^20.3.0",
-    "@types/node-fetch": "^2.6.4",
     "@types/uuid": "^9.0.2"
   },
   "dependencies": {
@@ -19,7 +18,6 @@
     "@vercel/ncc": "^0.36.1",
     "form-data": "^4.0.0",
     "jsonwebtoken": "^9.0.0",
-    "node-fetch": "2",
     "typescript": "^5.0.4",
     "uuid": "^9.0.0"
   },

--- a/src/amo.ts
+++ b/src/amo.ts
@@ -1,7 +1,6 @@
 import type { ReadStream } from "node:fs";
 import FormData from "form-data";
 import jwt from "jsonwebtoken";
-import fetch from "node-fetch";
 import { v4 as uuidv4 } from "uuid";
 
 type VersionRange = { min?: string; max?: string };


### PR DESCRIPTION
Bump runtime version to node 20 and use naive [fetch()](https://nodejs.org/dist/latest-v20.x/docs/api/globals.html#fetch) in Node.js.